### PR TITLE
URL Cleanup

### DIFF
--- a/org.springextensions.db4o-it-osgi/pom.xml
+++ b/org.springextensions.db4o-it-osgi/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>org.springextensions.db4o-it-osgi</artifactId>
   <name>Spring db4o Extension IT OSGi</name>
 
-  <url>http://www.springsource.org/extensions/se-db4o</url>
+  <url>https://www.springsource.org/extensions/se-db4o</url>
 
   <description>OSGi Integration Tests for Spring db4o Extension</description>
 

--- a/org.springextensions.db4o-it-spring/pom.xml
+++ b/org.springextensions.db4o-it-spring/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>org.springextensions.db4o-it-spring</artifactId>
   <name>Spring db4o Extension IT Spring</name>
 
-  <url>http://www.springsource.org/extensions/se-db4o</url>
+  <url>https://www.springsource.org/extensions/se-db4o</url>
 
   <description>Spring Integration Tests for Spring db4o Extension</description>
 

--- a/org.springextensions.db4o/pom.xml
+++ b/org.springextensions.db4o/pom.xml
@@ -15,7 +15,7 @@
   <name>Spring db4o Extension</name>
   <packaging>bundle</packaging>
 
-  <url>http://www.springsource.org/extensions/se-db4o</url>
+  <url>https://www.springsource.org/extensions/se-db4o</url>
 
   <dependencies>
     <!-- Spring Framework -->
@@ -129,8 +129,8 @@
               <artifactId>maven-javadoc-plugin</artifactId>
               <configuration>
                 <links>
-                  <link>http://developer.db4o.com/Documentation/Reference/db4o-8.0/java/api/</link>
-                  <link>http://static.springsource.org/spring/docs/3.0.x/javadoc-api/</link>
+                  <link>https://developer.db4o.com/Documentation/Reference/db4o-8.0/java/api/</link>
+                  <link>https://docs.spring.io/spring/docs/3.0.x/javadoc-api/</link>
                 </links>
               </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,20 +10,20 @@
   <name>Spring db4o Extension Project</name>
   <packaging>pom</packaging>
 
-  <url>http://www.springsource.org/extensions/se-db4o</url>
+  <url>https://www.springsource.org/extensions/se-db4o</url>
 
   <description>Spring extension for anyone integrating db4o into an enterprise application wishing to achieve declarative transaction management, exception translation and ease of configuration.</description>
 
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
 
   <organization>
     <name>Spring db4o Community</name>
-    <url>http://www.springsource.org/extensions/se-db4o</url>
+    <url>https://www.springsource.org/extensions/se-db4o</url>
   </organization>
 
   <developers>
@@ -44,13 +44,13 @@
   </issueManagement>
 
   <ciManagement>
-    <url>http://build.springsource.org/browse/EXT-DB4OSNAPSHOT</url>
+    <url>https://build.springsource.org/browse/EXT-DB4OSNAPSHOT</url>
   </ciManagement>
 
   <distributionManagement>
     <site>
       <id>springsource.org</id>
-      <url>http://www.springsource.org/extensions/se-db4o</url>
+      <url>https://www.springsource.org/extensions/se-db4o</url>
     </site>
     <repository>
       <id>de.oliverlietz.maven</id>
@@ -249,19 +249,19 @@
   <repositories>
     <repository>
       <id>org.springsource.repo.release</id>
-      <url>http://repo.springsource.org/release</url>
+      <url>https://repo.springsource.org/release</url>
     </repository>
     <repository>
       <id>com.springsource.repository.bundles.release</id>
-      <url>http://repository.springsource.com/maven/bundles/release</url>
+      <url>https://repository.springsource.com/maven/bundles/release</url>
     </repository>
     <repository>
       <id>com.springsource.repository.bundles.external</id>
-      <url>http://repository.springsource.com/maven/bundles/external</url>
+      <url>https://repository.springsource.com/maven/bundles/external</url>
     </repository>
     <repository>
       <id>de.oliverlietz.maven</id>
-      <url>http://maven.oliverlietz.de</url>
+      <url>https://maven.oliverlietz.de</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://developer.db4o.com/Documentation/Reference/db4o-8.0/java/api/ (ConnectTimeoutException) migrated to:  
  https://developer.db4o.com/Documentation/Reference/db4o-8.0/java/api/ ([https](https://developer.db4o.com/Documentation/Reference/db4o-8.0/java/api/) result ConnectTimeoutException).
* http://maven.oliverlietz.de (UnknownHostException) migrated to:  
  https://maven.oliverlietz.de ([https](https://maven.oliverlietz.de) result UnknownHostException).
* http://repository.springsource.com/maven/bundles/external (404) migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://static.springsource.org/spring/docs/3.0.x/javadoc-api/ (301) migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api/ ([https](https://static.springsource.org/spring/docs/3.0.x/javadoc-api/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://build.springsource.org/browse/EXT-DB4OSNAPSHOT migrated to:  
  https://build.springsource.org/browse/EXT-DB4OSNAPSHOT ([https](https://build.springsource.org/browse/EXT-DB4OSNAPSHOT) result 301).
* http://repo.springsource.org/release migrated to:  
  https://repo.springsource.org/release ([https](https://repo.springsource.org/release) result 301).
* http://www.springsource.org/extensions/se-db4o migrated to:  
  https://www.springsource.org/extensions/se-db4o ([https](https://www.springsource.org/extensions/se-db4o) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance