### PR TITLE
URL Cleanup

### DIFF
--- a/org.springextensions.db4o-it-osgi/src/test/java/org/springextensions/db4o/BlueprintIT.java
+++ b/org.springextensions.db4o-it-osgi/src/test/java/org/springextensions/db4o/BlueprintIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/EmbeddedClientServerIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/EmbeddedClientServerIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/EmbeddedIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/EmbeddedIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/ObjectContainerIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/ObjectContainerIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/RemoteClientServerIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/RemoteClientServerIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/ClientConfigurationIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/ClientConfigurationIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/EmbeddedConfigurationIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/EmbeddedConfigurationIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/ObjectClassConfigurerIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/ObjectClassConfigurerIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/ServerConfigurationIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/config/ServerConfigurationIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/example/ResourceLoaderFactory.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/example/ResourceLoaderFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/io/ResourceStorageIT.java
+++ b/org.springextensions.db4o-it-spring/src/test/java/org/springextensions/db4o/io/ResourceStorageIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oAccessor.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oCallback.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oOperations.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oSystemException.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oSystemException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oTemplate.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oTransactionManager.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/Db4oTransactionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectContainerFactoryBean.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectContainerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectContainerHolder.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectContainerHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectServerFactoryBean.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectServerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectServerUtils.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/ObjectServerUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ClientConfigurationFactoryBean.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ClientConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/CommonConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/CommonConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/DiagnosticConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/DiagnosticConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/EmbeddedConfigurationFactoryBean.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/EmbeddedConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/EnvironmentConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/EnvironmentConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/FileConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/FileConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/FreespaceConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/FreespaceConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/IdSystemConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/IdSystemConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/NetworkingConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/NetworkingConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ObjectClassConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ObjectClassConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ObjectFieldConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ObjectFieldConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/QueryConfigurer.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/QueryConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ServerConfigurationFactoryBean.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/config/ServerConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/io/ResourceStorage.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/io/ResourceStorage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/main/java/org/springextensions/db4o/support/Db4oDaoSupport.java
+++ b/org.springextensions.db4o/src/main/java/org/springextensions/db4o/support/Db4oDaoSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/Db4oTemplateTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/Db4oTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/Db4oTransactionManagerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/Db4oTransactionManagerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/ObjectContainerFactoryBeanTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/ObjectContainerFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/ObjectContainerHolderTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/ObjectContainerHolderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/ObjectServerFactoryBeanTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/ObjectServerFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ClientConfigurationFactoryBeanTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ClientConfigurationFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/CommonConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/CommonConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/DiagnosticConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/DiagnosticConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/EmbeddedConfigurationFactoryBeanTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/EmbeddedConfigurationFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/EnvironmentConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/EnvironmentConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/FileConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/FileConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/FreespaceConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/FreespaceConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/IdSystemConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/IdSystemConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/NetworkingConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/NetworkingConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ObjectClassConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ObjectClassConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ObjectFieldConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ObjectFieldConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/QueryConfigurerTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/QueryConfigurerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ServerConfigurationFactoryBeanTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/config/ServerConfigurationFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopClientConfigurationItem.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopClientConfigurationItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopDiagnosticListener.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopDiagnosticListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopEmbeddedConfigurationItem.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopEmbeddedConfigurationItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopFreespaceFiller.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopFreespaceFiller.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopMessageRecipient.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopMessageRecipient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopServerConfigurationItem.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/NoopServerConfigurationItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/Person.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/PersonTypeHandlerPredicate.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/example/PersonTypeHandlerPredicate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/io/ResourceStorageTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/io/ResourceStorageTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springextensions.db4o/src/test/java/org/springextensions/db4o/support/Db4oDaoSupportTest.java
+++ b/org.springextensions.db4o/src/test/java/org/springextensions/db4o/support/Db4oDaoSupportTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 64 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).